### PR TITLE
Document native pipe (|>) compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ For a full tutorial with rendered figures, see the
 MRIcrotome is designed to be used with pipes. A typical workflow starts with
 `sliceSeries()`, adds layers such as `anatomy()`, `overlay()`, or
 `contours()`, optionally adds `legend()` and `addtitle()`, and finishes with
-`draw()`.
+`draw()`. Both the magrittr pipe (`%>%`) and the R 4.1+ native pipe (`|>`)
+are supported.
 
 ```r
 library(MRIcrotome)


### PR DESCRIPTION
## Problem
Issue #20 asks about native R pipe (`|>`) compatibility. MRIcrotome's pipe functions all take `ssm` as the first argument, which is exactly what `|>` passes — no special handling needed.

## Change
One-line README addition noting both `%>%` and `|>` are supported.

No code changes required — it already works.

Fixes #20